### PR TITLE
Extend URI scheme with single stake pool links

### DIFF
--- a/CIP-0013/CIP-0013.md
+++ b/CIP-0013/CIP-0013.md
@@ -1,7 +1,7 @@
 ---
 CIP: 13
 Title: Cardano URI Scheme
-Authors: Sebastien Guillemot <sebastien@emurgo.io>, Vicente Almonacid <vicente@emurgo.io>, Robert Phair <rphair@cosd.com>
+Authors: Sebastien Guillemot <sebastien@emurgo.io>, Vicente Almonacid <vicente@emurgo.io>, Robert Phair <rphair@cosd.com>, Nicolas Arqueros <nicolas@emurgo.io>
 Comments-URI:
 - https://github.com/Emurgo/EmIPs/pull/2
 - https://forum.cardano.org/t/cip-cardano-payment-uri-scheme/41457
@@ -45,12 +45,13 @@ The core implementation should follow the [BIP-21](https://github.com/bitcoin/bi
 Rationale:
 - Use `cardano:` over `ada:` as other projects that implement this standard tend to take the project name over the currency name (this makes sense if we consider this protocol as a generic way for interacting with the blockchain through wallets - as opposed to a simple payment system)
 - Many wallets support multiple currencies. Following the same standard will ensure higher adoption of our protocol.
+- In order to make this CIP friendly to future capabilities, all the parameters will need to have their key name specified. 
 
 Examples:
 ```
 <a href="web+cardano:Ae2tdPwUPEZ76BjmWDTS7poTekAvNqBjgfthF92pSLSDVpRVnLP7meaFhVd">Donate</a>
-<a href="web+cardano://stake?c94e6fe1123bf111b77b57994bcd836af8ba2b3aa72cfcefbec2d3d4">Stake with us</a>
-<a href="web+cardano://stake?COSD">Choose our least saturated pool</a>
+<a href="web+cardano://delegate?poolhexid=c94e6fe1123bf111b77b57994bcd836af8ba2b3aa72cfcefbec2d3d4">Stake with us</a>
+<a href="web+cardano://delegate?poolticker=COSD">Choose our least saturated pool</a>
 ```
 
 ## Considerations
@@ -64,7 +65,7 @@ Examples:
 This is an initial, simplified protocol definition for fast implementation; it only requires:
 
 * for a payment URI (authority unspecified), an address and an optional amount parameter;
-* for a stake pool URI (authority = `stake`), a single stake pool reference.
+* for a stake pool URI (authority = `delegate`), a single stake pool reference, and provide the key name of its type.  
 
 As discussed above, these rules are likely to evolve in time in order to support additional features, including multiple stake pool references (in proportions defining a "portfolio") and other unique capabilities of the Cardano blockchain.
 
@@ -75,10 +76,10 @@ paymentref = cardanoaddress [ "?" amountparam ]
 cardanoaddress = *(base58 | bech32)
 amountparam = "amount=" *digit [ "." *digit ]
 
-stakepoolref = "//stake?" stakepool
+stakepoolref = "//delegate?" stakepool
 stakepool = poolhexid | poolticker
-poolhexid = 56HEXDIG
-poolticker = 3*5UNICODE
+poolhexid = "poolhexid=" 56HEXDIG
+poolticker = "poolticker=" 3*5UNICODE
 ```
 
 ### Payment URI queries
@@ -103,7 +104,7 @@ These yet unsupported parameters in the URI query string should (by preference o
 ## Security Considerations
 
 1. For payment links, we cannot prompt the user to send the funds right away as they may not be fully aware of the URI they clicked or were redirected to. Instead, it may be better to simply pre-populate fields in a transaction.
-2. For either payment or staking links, we should be wary of people who disguise links as actually opening up a phishing website that LOOKS like that corresponding part of the wallet UI.
+2. For either payment or delegation links, we should be wary of people who disguise links as actually opening up a phishing website that LOOKS like that corresponding part of the wallet UI.
 
 # Rationale
 


### PR DESCRIPTION
Hello CIP editors!

I know that the next CIP meeting is today, so in order to be able to make it in time, I created this PR on top of the work of @rphair. Why?

- Fixes the usage of the terminology `stake` (it should be `delegate`). Users delegate to stakepools, and stakepools are the ones that stake.
- To make this more friendly to future extension of URI, I updated it the parameter key names are always passed. In the future, we could have more advance features that would require the usage of parameter names and it will look strange that sometimes we enforce that for some actions (delegate) and for others don't.
